### PR TITLE
Code cleanup & various other improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,36 @@ int main(int argc, char const *argv[]) {
 }
 ```
 
+##### 4. Colours!
+```cpp
+#include <iostream>
+#include "../module.h"
+
+
+int main(int argc, char const *argv[]) {
+
+    ws::module::println(
+        ws::module::style::bold,
+        ws::module::colour::bg::magenta,
+        "Testing... "
+    );
+
+    ws::module::noticeln("Notice");
+    ws::module::warnln("Warn ");
+    ws::module::errorln("Error ");
+
+    ws::module::println(
+        ws::module::colour::fg::bright::green, "Yes!",
+        " ",
+        ws::module::colour::fg::bright::red, "No!"
+    );
+
+    ws::module::rainbowln("Hello ", "how ", "are ", "you?");
+
+    return 0;
+}
+```
+
 ### Run
 
 > Note: This works with `bash` but should also work with other shells that support the same functionality.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # module
+
 A simple header for making the task of piping data between processes easier.
 
-### Examples
+## Examples
 
-##### 1. Processing streamed data
+#### 1. Processing streamed data
 
 ```cpp
 #include <iostream>
@@ -29,7 +30,7 @@ int main(int argc, char const *argv[]) {
 }
 ```
 
-##### 2. Processing accumulated data
+#### 2. Processing accumulated data
 
 ```cpp
 #include <iostream>
@@ -51,7 +52,8 @@ int main(int argc, char const *argv[]) {
 }
 ```
 
-##### 3. Logging & IO
+#### 3. Logging & IO
+
 ```cpp
 #include <iostream>
 #include "module.h"
@@ -83,7 +85,8 @@ int main(int argc, char const *argv[]) {
 }
 ```
 
-##### 4. Colours!
+#### 4. Colours!
+
 ```cpp
 #include <iostream>
 #include "../module.h"
@@ -113,7 +116,7 @@ int main(int argc, char const *argv[]) {
 }
 ```
 
-### Run
+## Run
 
 > Note: This works with `bash` but should also work with other shells that support the same functionality.
 
@@ -124,3 +127,60 @@ int main(int argc, char const *argv[]) {
 `./reciever.out < <filename>`
 
 `cat <filename> | ./reciever.out | ./reciever.out`
+
+## Interface
+
+> Note: anything defined within the "details" namespace is used internally and should not be used directly by the user.
+
+#### Constants & Globals
+
+| Styles  | ws::module::style::                             |
+| ------- | ----------------------------------------------- |
+| bold    | Makes the text bold.                            |
+| reverse | Swaps the background and foreground colours.    |
+| reset   | Reset the style so the text appears normal.     |
+| notice  | Set the text to bold and use the notice colour. |
+| warn    | Set the text to bold and use the warn colour.   |
+| error   | Set the text to bold and use the error colour.  |
+
+| Streams | ws::module::                       |
+| :------ | ---------------------------------- |
+| printer | Alias the std::cerr output steam.  |
+| piper   | Alias the std::cout output stream. |
+
+| Colours | ws::module::colour::                                     |
+| ------- | -------------------------------------------------------- |
+| black   | Looks like coal.                                         |
+| red     | Same colour as the liquid being pumped around your body. |
+| green   | That furry stuff that grows in your garden colour.       |
+| yellow  | The Sun. (don't stare at it)                             |
+| blue    | The Ocean or The Sky depending on shade.                 |
+| magenta | Some flowers look like this.                             |
+| cyan    | Also flowers.                                            |
+| grey    | All fifty shades of it.                                  |
+
+> All of the above colours exist in `fg::`, `bg::`, `fg::bright::` and `bg::bright::`.
+
+| Special Colours | ws::module::colour::        |
+| --------------- | --------------------------- |
+| notice          | Colour to use for notices.  |
+| warn            | Colour to use for warnings. |
+| error           | Colour to use for errors.   |
+
+#### Functions.
+
+| Data Handling | ws::module::                                                 |
+| ------------- | ------------------------------------------------------------ |
+| receive       | Recieve data on std::cin in chunks of N bytes using a callback. |
+| receive_all   | Accumulate all the data from std::cin and return a std::string. |
+
+| Logging | ws::module::                                                 |
+| ------- | ------------------------------------------------------------ |
+| print   | Prints a list of objects to ws::module::printer and appends ws::module::style::reset. |
+| pipe    | Same as print but outputs to ws::module::piper.              |
+| notice  | Same as print but prepends message with `[-]` and uses ws::module::style::notice. |
+| warn    | Same as print but prepends message with `[*]` and uses ws::module::style::warn. |
+| error   | Same as print but prepends message with `[!]` and uses ws::module::style::error. |
+| rainbow | Same as print but prints each object with a random colour.   |
+
+> All of the above functions also have newline variants like: `println` or `errorln` etc.

--- a/module.h
+++ b/module.h
@@ -137,33 +137,39 @@ namespace ws::module {
         // Reset style, BG and FG all at once.
         struct Reset {};
 
-        std::ostream& operator<<(std::ostream& os, const Reset& obj) {
-            return (os << rang::style::reset << rang::fg::reset << rang::bg::reset);
-        }
-
-
-        // Notice style.
+        // Notice style, set bold and notice colour.
         struct Notice {};
 
-        inline std::ostream& operator<<(std::ostream& os, const Notice& obj) {
-            return (os << style::bold << colour::notice);
-        }
-
-
-        // Warn style.
+        // Warn style, set bold and warn colour.
         struct Warn {};
 
-        inline std::ostream& operator<<(std::ostream& os, const Warn& obj) {
-            return (os << style::bold << colour::warn);
-        }
-
-
-        // Error style.
+        // Error style, set bold and error colour.
         struct Error {};
+    }
 
-        inline std::ostream& operator<<(std::ostream& os, const Error& obj) {
-            return (os << style::bold << colour::error);
-        }
+
+
+    // Overloads.
+    inline std::ostream& operator<<(std::ostream& os, const Reset& obj) {
+        return (os << rang::style::reset << rang::fg::reset << rang::bg::reset);
+    }
+
+
+
+    inline std::ostream& operator<<(std::ostream& os, const Notice& obj) {
+        return (os << style::bold << colour::notice);
+    }
+
+
+
+    inline std::ostream& operator<<(std::ostream& os, const Warn& obj) {
+        return (os << style::bold << colour::warn);
+    }
+
+
+
+    inline std::ostream& operator<<(std::ostream& os, const Error& obj) {
+        return (os << style::bold << colour::error);
     }
 
 
@@ -301,7 +307,7 @@ namespace ws::module {
         using colour_t = decltype(colour::fg::bright::black);
 
 
-        inline constexpr colour_t palette[] = {
+        constexpr colour_t palette[] = {
             colour::fg::bright::red,
             colour::fg::bright::green,
             colour::fg::bright::yellow,

--- a/module.h
+++ b/module.h
@@ -7,7 +7,10 @@
 #include <iostream>
 #include <functional>
 #include <vector>
+#include <array>
 #include <utility>
+#include <random>
+
 
 #include "rang/include/rang.hpp"
 
@@ -56,14 +59,142 @@ namespace ws::module {
 
 
 
+
+    // Colours.
+    #define NEW_COLOUR(name, val) constexpr auto name = val;
+
+
+    namespace colour {
+        namespace fg {
+            NEW_COLOUR(black,   rang::fg::black);
+            NEW_COLOUR(red,     rang::fg::red);
+            NEW_COLOUR(green,   rang::fg::green);
+            NEW_COLOUR(yellow,  rang::fg::yellow);
+            NEW_COLOUR(blue,    rang::fg::blue);
+            NEW_COLOUR(magenta, rang::fg::magenta);
+            NEW_COLOUR(cyan,    rang::fg::cyan);
+            NEW_COLOUR(grey,    rang::fg::gray);
+
+            namespace bright {
+                NEW_COLOUR(black,   rang::fgB::black);
+                NEW_COLOUR(red,     rang::fgB::red);
+                NEW_COLOUR(green,   rang::fgB::green);
+                NEW_COLOUR(yellow,  rang::fgB::yellow);
+                NEW_COLOUR(blue,    rang::fgB::blue);
+                NEW_COLOUR(magenta, rang::fgB::magenta);
+                NEW_COLOUR(cyan,    rang::fgB::cyan);
+                NEW_COLOUR(grey,    rang::fgB::gray);
+            }
+        }
+
+
+        namespace bg {
+            NEW_COLOUR(black,   rang::bg::black);
+            NEW_COLOUR(red,     rang::bg::red);
+            NEW_COLOUR(green,   rang::bg::green);
+            NEW_COLOUR(yellow,  rang::bg::yellow);
+            NEW_COLOUR(blue,    rang::bg::blue);
+            NEW_COLOUR(magenta, rang::bg::magenta);
+            NEW_COLOUR(cyan,    rang::bg::cyan);
+            NEW_COLOUR(grey,    rang::bg::gray);
+
+            namespace bright {
+                NEW_COLOUR(black,   rang::bgB::black);
+                NEW_COLOUR(red,     rang::bgB::red);
+                NEW_COLOUR(green,   rang::bgB::green);
+                NEW_COLOUR(yellow,  rang::bgB::yellow);
+                NEW_COLOUR(blue,    rang::bgB::blue);
+                NEW_COLOUR(magenta, rang::bgB::magenta);
+                NEW_COLOUR(cyan,    rang::bgB::cyan);
+                NEW_COLOUR(grey,    rang::bgB::gray);
+            }
+        }
+
+
+        NEW_COLOUR(notice, fg::bright::blue);
+        NEW_COLOUR(warn,   fg::bright::yellow);
+        NEW_COLOUR(error,  fg::bright::red);
+    }
+
+
+    #undef NEW_COLOUR
+
+
+
+
+
+
+    // Styles.
+    namespace style {
+        // These are the most universally supported styles.
+        constexpr auto bold = rang::style::bold;
+        constexpr auto reverse = rang::style::reversed;
+    }
+
+
+
+    namespace {
+        // Reset style, BG and FG all at once.
+        struct Reset {};
+
+        std::ostream& operator<<(std::ostream& os, const Reset& obj) {
+            return (os << rang::style::reset << rang::fg::reset << rang::bg::reset);
+        }
+
+
+        // Notice style.
+        struct Notice {};
+
+        std::ostream& operator<<(std::ostream& os, const Notice& obj) {
+            return (os << style::bold << colour::notice);
+        }
+
+
+        // Warn style.
+        struct Warn {};
+
+        std::ostream& operator<<(std::ostream& os, const Warn& obj) {
+            return (os << style::bold << colour::warn);
+        }
+
+
+        // Error style.
+        struct Error {};
+
+        std::ostream& operator<<(std::ostream& os, const Error& obj) {
+            return (os << style::bold << colour::error);
+        }
+    }
+
+
+
+
+    // Custom styles
+    namespace style {
+        inline Reset reset;
+        inline Notice notice;
+        inline Warn warn;
+        inline Error error;
+    }
+
+
+
+    // Output symbols
+    namespace {
+        constexpr auto SYMBOL_NOTICE = "[-] ";
+        constexpr auto SYMBOL_WARN   = "[*] ";
+        constexpr auto SYMBOL_ERROR  = "[!] ";
+    }
+
+
+
     // Streams.
     inline std::ostream& piper = std::cout;
     inline std::ostream& printer = std::cerr;
 
-    // Output symbols
-    constexpr auto SYMBOL_NOTICE = "[-] ";
-    constexpr auto SYMBOL_WARN   = "[*] ";
-    constexpr auto SYMBOL_ERROR  = "[!] ";
+
+
+
 
 
 
@@ -72,7 +203,12 @@ namespace ws::module {
     // Logging and IO.
     template<typename... Ts>
     inline std::ostream& print(Ts&&... args) {
-        return (ws::module::printer << ... << std::forward<Ts&&>(args));
+        return (
+            ws::module::printer <<
+                style::reset <<
+                ... <<
+                std::forward<Ts&&>(args)
+        ) << style::reset;
     }
 
 
@@ -84,124 +220,121 @@ namespace ws::module {
 
 
 
-    template<typename... Ts>
-    inline std::ostream& notice(Ts&&... args) {
-        return ws::module::print(SYMBOL_NOTICE, std::forward<Ts&&>(args)...);
-    }
 
 
 
-    template<typename... Ts>
-    inline std::ostream& warn(Ts&&... args) {
-        return ws::module::print(SYMBOL_WARN, std::forward<Ts&&>(args)...);
-    }
-
-
-
-    template<typename... Ts>
-    inline std::ostream& error(Ts&&... args) {
-        return ws::module::print(SYMBOL_ERROR, std::forward<Ts&&>(args)...);
-    }
-
-
-
-
-
-
-    // Logging and IO with line endings...
+    // Logging and IO...
     template<typename... Ts>
     inline std::ostream& println(Ts&&... args) {
-        return ws::module::print(std::forward<Ts&&>(args)...) << "\n";
+        return ws::module::print(std::forward<Ts&&>(args)...) << '\n';
     }
 
 
 
     template<typename... Ts>
     inline std::ostream& pipeln(Ts&&... args) {
-        return ws::module::pipe(std::forward<Ts&&>(args)...) << "\n";
+        return ws::module::pipe(std::forward<Ts&&>(args)...) << '\n';
+    }
+
+
+
+
+
+
+    // Logging with colour.
+    template<typename... Ts>
+    inline std::ostream& notice(Ts&&... args) {
+        ws::module::print(style::notice, SYMBOL_NOTICE);
+        return ws::module::print(std::forward<Ts&&>(args)...);
     }
 
 
 
     template<typename... Ts>
+    inline std::ostream& warn(Ts&&... args) {
+        ws::module::print(style::warn, SYMBOL_WARN);
+        return ws::module::print(std::forward<Ts&&>(args)...);
+    }
+
+
+
+    template<typename... Ts>
+    inline std::ostream& error(Ts&&... args) {
+        ws::module::print(style::error, SYMBOL_ERROR);
+        return ws::module::print(std::forward<Ts&&>(args)...);
+    }
+
+
+
+    // Print lines too.
+    template<typename... Ts>
     inline std::ostream& noticeln(Ts&&... args) {
-        return ws::module::notice(std::forward<Ts&&>(args)...) << "\n";
+        return ws::module::notice(std::forward<Ts&&>(args)..., '\n');
     }
 
 
 
     template<typename... Ts>
     inline std::ostream& warnln(Ts&&... args) {
-        return ws::module::warn(std::forward<Ts&&>(args)...) << "\n";
+        return ws::module::warn(std::forward<Ts&&>(args)..., '\n');
     }
 
 
 
     template<typename... Ts>
     inline std::ostream& errorln(Ts&&... args) {
-        return ws::module::error(std::forward<Ts&&>(args)...) << "\n";
-    }
-
-
-    //Coloured print functions 
-
-    using fg = rang::fgB;
-
-    constexpr auto NOTICE_COLOR = fg::blue;
-    constexpr auto WARN_COLOR   = fg::yellow;
-    constexpr auto ERROR_COLOR  = fg::red;
-
-    template<typename... Ts>
-    inline std::ostream& printc(fg colour, Ts&&... args) {
-        return ws::module::print(colour, std::forward<Ts&&>(args)..., rang::fg::reset);
-    }
-
-
-    template<typename... Ts>
-    inline std::ostream& noticec(Ts&&... args) {
-        ws::module::printc(NOTICE_COLOR, SYMBOL_NOTICE);
-        return ws::module::print(std::forward<Ts&&>(args)...);
-    }
-
-
-    template<typename... Ts>
-    inline std::ostream& warnc(Ts&&... args) {
-        ws::module::printc(WARN_COLOR, SYMBOL_WARN);
-        return ws::module::print(std::forward<Ts&&>(args)...);
-    }
-
-
-    template<typename... Ts>
-    inline std::ostream& errorc(Ts&&... args) {
-        ws::module::printc(ERROR_COLOR, SYMBOL_ERROR);
-        return ws::module::print(std::forward<Ts&&>(args)...);
-    }
-
-    template<typename... Ts>
-    inline std::ostream& printlnc(fg colour, Ts&&... args) {
-        return ws::module::printc(colour, std::forward<Ts&&>(args)..., '\n');
-    }
-
-
-    template<typename... Ts>
-    inline std::ostream& noticelnc(Ts&&... args) {
-        return ws::module::noticec(std::forward<Ts&&>(args)..., '\n');
+        return ws::module::error(std::forward<Ts&&>(args)..., '\n');
     }
 
 
 
-    template<typename... Ts>
-    inline std::ostream& warnlnc(Ts&&... args) {
-        return ws::module::warnc(std::forward<Ts&&>(args)..., '\n');
+
+
+
+
+
+
+    // Easter eggs
+    namespace {
+        std::random_device rd;
+        std::mt19937 rng(rd());
+        std::uniform_int_distribution<int> uni(0, 5);
+
+
+        using colour_t = decltype(colour::fg::bright::black);
+
+
+        colour_t random_colour() {
+            return std::array<colour_t, 6>{
+                colour::fg::bright::red,
+                colour::fg::bright::green,
+                colour::fg::bright::yellow,
+                colour::fg::bright::blue,
+                colour::fg::bright::magenta,
+                colour::fg::bright::cyan
+            }.at(uni(rng));
+        }
     }
 
 
-
-    template<typename... Ts>
-    inline std::ostream& errorlnc(Ts&&... args) {
-        return ws::module::errorc(std::forward<Ts&&>(args)..., '\n');
+    template <typename T>
+    inline std::ostream& rainbow(T&& arg) {
+        return ws::module::print(random_colour(), arg);
     }
-    
+
+
+    template <typename T1, typename T2, typename... Ts>
+    inline std::ostream& rainbow(T1&& arg1, T2&& arg2, Ts&&... args) {
+        ws::module::rainbow(arg1);
+        return ws::module::rainbow(arg2, std::forward<Ts&&>(args)...);
+    }
+
+
+    template <typename... Ts>
+    inline std::ostream& rainbowln(Ts&&... args) {
+        return ws::module::rainbow(std::forward<Ts&&>(args)..., '\n');
+    }
+
 }
 
 


### PR DESCRIPTION
- Cleaned up the code.

- Removed redundant functions.

- Logging functions use colours by default.

- Removed noticec, warnc and errorc.

- Defined colour constants explicitly to use correct namespace(fg::bright, bg::bright) and to rename some values (gray ->  grey).

- Created some custom style objects to allow for quick usage of multiple style/colour combinations with a single object (style::notice -> bold & blue).

- More usage of anonymous namespaces in order to not pollute the namespace with internal values etc.

- Rainbow colour function :P